### PR TITLE
Fix broken graph in memory widget

### DIFF
--- a/machine_controller.php
+++ b/machine_controller.php
@@ -187,7 +187,7 @@ class Machine_controller extends Module_controller
 
             default:
                 foreach ($tmp as $mem => $memcnt) {
-                    $out[] = array('label' => $mem, 'count' => $memcnt);
+                    $out[] = array('label' => $mem, 'count' => intval($memcnt));
                 }
         }
 


### PR DESCRIPTION
The get_memory_stats JSON contains the machine count as a string instead of an integer, breaking the horizontal scale of the graph bars. 
This is a regression in the latest commit of a bug from Feb 2017. Arjen originally fixed it in machine_controller.php, then later moved the fix to machine_model.php. When machine model was rewritten, the code containing the `intval` function was removed.