### PR TITLE
Add new model lookup capabilities

### DIFF
--- a/helpers/model_lookup_helper.php
+++ b/helpers/model_lookup_helper.php
@@ -36,3 +36,34 @@ function machine_model_lookup($serial)
     }
 
 }
+
+function machine_icon_lookup($serial)
+{
+    $options = [
+        'query' => [
+            'page' => 'categorydata',
+            'serialnumber' => $serial
+        ]
+    ];
+
+    $client = new Request();
+    $result = $client->get('https://km.support.apple.com/kb/index', $options);
+
+    if ( ! $result) {
+        // returns the default Apple logo for any cases where we can't retrieve the icon.
+        return 'https://km.support.apple.com/kb/securedImage.jsp?productid='.$serial.'&size=240x240';
+    }
+
+    try {
+        $categorydata = json_decode($result);
+        if(isset($categorydata->id)){
+            return 'https://km.support.apple.com/kb/securedImage.jsp?productid='.$categorydata->id.'&size=240x240';
+        }
+        else{
+            return 'https://km.support.apple.com/kb/securedImage.jsp?productid='.$serial.'&size=240x240';
+        }
+    } catch (Exception $e) {
+        return 'https://km.support.apple.com/kb/securedImage.jsp?productid='.$serial.'&size=240x240';
+    }
+
+}

--- a/machine_controller.php
+++ b/machine_controller.php
@@ -313,4 +313,30 @@ class Machine_controller extends Module_controller
         ]);
 
     }
+
+    /**
+     * Run machine lookup at Apple
+     *
+     **/
+    public function get_model_icon($serial_number)
+    {
+        require_once(__DIR__ . '/helpers/model_lookup_helper.php');
+        $out = ['error' => '', 'url' => ''];
+        try {
+            $machine = Machine_model::select()
+                ->where('serial_number', $serial_number)
+                ->firstOrFail();
+            $machine->img_url = machine_icon_lookup($serial_number);
+            $machine->save();
+            $out['url'] = $machine->img_url;
+        } catch (\Throwable $th) {
+            // Record does not exist
+            $out['error'] = 'lookup_failed';
+        }
+        $obj = new View();
+        $obj->view('json', [
+            'msg' => $out
+        ]);
+
+    }
 } // END class Machine_controller

--- a/views/machine_detail_widget1.php
+++ b/views/machine_detail_widget1.php
@@ -15,12 +15,12 @@
 
 <script>
 
-    var apple_hardware_icon_url = "<?=conf('apple_hardware_icon_url')?>";
-    $('#apple_hardware_icon')
-        .attr('src', apple_hardware_icon_url.replace('%s&amp;', serialNumber.substring(8) + '&' ))
-    
+    $.getJSON(appUrl + '/module/machine/get_model_icon/' + serialNumber, function(data) {
+        $('#apple_hardware_icon')
+          .attr('src', data['url'])
+    });
     // ------------------------------------ Refresh machine description
-	$('.machine-refresh-desc')
+        $('.machine-refresh-desc')
         .attr('href', appUrl + '/module/machine/model_lookup/' + serialNumber)
         .click(function(e){
             e.preventDefault();


### PR DESCRIPTION
This PR fixes not being able to resolve icons for newer Macs.
- Adds new helper to lookup the icon (get the models ID from the serial, and then get the icon from the ID)
- Add new method in controller to wrap around the above helper
- Updated view to fetch from the helper

This reuses the `img_url` column that already exists in the `machine` table.

Fixes [#1475 in the main repo](https://github.com/munkireport/munkireport-php/issues/1475)