### PR TITLE
Update to provide all icons

### DIFF
--- a/views/machine_detail_widget1.php
+++ b/views/machine_detail_widget1.php
@@ -15,31 +15,6 @@
 </div>
 
 <script>
-let mac_color = ''; // Shared variable across both functions
-
-$(document).ready(function () {
-
-    $.getJSON(appUrl + '/module/ibridge/get_data/' + serialNumber)
-    .done(function (data) {
-		if (Array.isArray(data) && data.length > 0 && data[0] && data[0].device_color) {
-    		mac_color = data[0].device_color.toLowerCase().replace(/\s+/g, '');
-    		console.log("mac_color:", mac_color);
-    		$('.mac_color').text(mac_color);
-		} else {
-    		console.warn("iBridge data is empty or invalid:", data);
-    		mac_color = "";
-    	$('.mac_color').text('');
-		}        
-	loadMachineData();
-    })
-    .fail(function (jqXHR, textStatus, errorThrown) {
-        console.error("Failed to fetch iBridge data:", textStatus, errorThrown);
-        mac_color = "";
-        $('.mac_color').text('');
-        loadMachineData();
-    });
-    
-    
 function loadMachineData() {
     $.getJSON(appUrl + '/module/machine/report/' + serialNumber, function (data) {
         let mac_name = data.machine_name ? data.machine_name.replace(/ /g, '') : '';
@@ -50,14 +25,8 @@ function loadMachineData() {
             mac_name = "iMac";
         }
 
-        // Override for 13" 2022 Macbook Air Starlight color doesn't work
-        if (mac_color == "starlight" && mac_model == "Mac14,2"){
-           mac_color = "silver"
-        }
-
         console.log("mac_name:", mac_name);
         console.log("mac_model:", mac_model);
-        console.log("mac_color (used in URL):", mac_color);
 
         $('.mac_name').text(mac_name);
         $('.mac_model').text(mac_model);
@@ -65,28 +34,19 @@ function loadMachineData() {
         // Construct base image URL
         let imageUrl = "https://statici.icloud.com/fmipmobile/deviceImages-9.0/" +
             encodeURIComponent(mac_name) + "/" +
-            encodeURIComponent(mac_model);
-
-        // Append mac_color if it's valid and model is not iMacPro1,1
-        if (mac_model !== "iMacPro1,1" && mac_color && mac_color.trim()) {
-            imageUrl += "-" + encodeURIComponent(mac_color);
-        }
-        imageUrl += "/online-infobox__2x.png";
+            encodeURIComponent(mac_model) +
+            "/online-infobox__2x.png";
 
         $('#apple_mac_icon').attr('src', imageUrl);
-
-        // Update alt attribute dynamically
-        const altText = `Image of ${mac_name} model ${mac_model} color ${mac_color}`;
-        $('#apple_mac_icon').attr('alt', altText);
     });
 }
 
-    // Only call loadIbridgeData initially; it will call loadMachineData after mac_color is set
-    loadIbridgeData();
+$(document).ready(function () {
+    loadMachineData();
 
     $('.machine-refresh-desc').on('click', function (e) {
         e.preventDefault();
-        loadIbridgeData(); // Same logic for refresh
+        loadMachineData();
     });
 });
 </script>

--- a/views/machine_detail_widget1.php
+++ b/views/machine_detail_widget1.php
@@ -1,7 +1,7 @@
 <div class="col-lg-4">
     <div class="row">
         <div class="col-xs-6">
-            <img id="apple_hardware_icon" class="img-responsive">
+            <img id="apple_mac_icon" class="img-responsive" alt="Mac Image">
         </div>
         <div class="col-xs-6" style="font-size: 1.4em; overflow: hidden">
             <span class="label label-info">macOS <span class="machine-os_version"></span></span><br>
@@ -10,29 +10,83 @@
             <span class="label label-info"><span class="reportdata-remote_ip"></span></span><br>
         </div>
     </div>
-    <span class="machine-machine_desc"></span> <a class="machine-refresh-desc" href=""><i class="fa fa-refresh"></i></a>
+    <span class="machine-machine_desc"></span>
+    <a class="machine-refresh-desc" href="#"><i class="fa fa-refresh"></i></a>
 </div>
 
 <script>
+let mac_color = ''; // Shared variable across both functions
 
-    $.getJSON(appUrl + '/module/machine/get_model_icon/' + serialNumber, function(data) {
-        $('#apple_hardware_icon')
-          .attr('src', data['url'])
+$(document).ready(function () {
+
+    $.getJSON(appUrl + '/module/ibridge/get_data/' + serialNumber)
+    .done(function (data) {
+		if (Array.isArray(data) && data.length > 0 && data[0] && data[0].device_color) {
+    		mac_color = data[0].device_color.toLowerCase().replace(/\s+/g, '');
+    		console.log("mac_color:", mac_color);
+    		$('.mac_color').text(mac_color);
+		} else {
+    		console.warn("iBridge data is empty or invalid:", data);
+    		mac_color = "";
+    	$('.mac_color').text('');
+		}        
+	loadMachineData();
+    })
+    .fail(function (jqXHR, textStatus, errorThrown) {
+        console.error("Failed to fetch iBridge data:", textStatus, errorThrown);
+        mac_color = "";
+        $('.mac_color').text('');
+        loadMachineData();
     });
-    // ------------------------------------ Refresh machine description
-        $('.machine-refresh-desc')
-        .attr('href', appUrl + '/module/machine/model_lookup/' + serialNumber)
-        .click(function(e){
-            e.preventDefault();
-            // show that we're doing a lookup
-            $('.machine-machine_desc').text(i18n.t('loading'));
-            $.getJSON( appUrl + '/module/machine/model_lookup/' + serialNumber, function( data ) {
-                if(data['error'] == ''){
-                    $('.machine-machine_desc').text(data['model']);
-                }
-                else{
-                    $('.machine-machine_desc').text(data['error']);
-                }
-            });
-        });
+    
+    
+function loadMachineData() {
+    $.getJSON(appUrl + '/module/machine/report/' + serialNumber, function (data) {
+        let mac_name = data.machine_name ? data.machine_name.replace(/ /g, '') : '';
+        const mac_model = data.machine_model || '';
+
+        // Override mac_name if mac_model is iMacPro1,1
+        if (mac_model === "iMacPro1,1") {
+            mac_name = "iMac";
+        }
+
+        // Override for 13" 2022 Macbook Air Starlight color doesn't work
+        if (mac_color == "starlight" && mac_model == "Mac14,2"){
+           mac_color = "silver"
+        }
+
+        console.log("mac_name:", mac_name);
+        console.log("mac_model:", mac_model);
+        console.log("mac_color (used in URL):", mac_color);
+
+        $('.mac_name').text(mac_name);
+        $('.mac_model').text(mac_model);
+
+        // Construct base image URL
+        let imageUrl = "https://statici.icloud.com/fmipmobile/deviceImages-9.0/" +
+            encodeURIComponent(mac_name) + "/" +
+            encodeURIComponent(mac_model);
+
+        // Append mac_color if it's valid and model is not iMacPro1,1
+        if (mac_model !== "iMacPro1,1" && mac_color && mac_color.trim()) {
+            imageUrl += "-" + encodeURIComponent(mac_color);
+        }
+        imageUrl += "/online-infobox__2x.png";
+
+        $('#apple_mac_icon').attr('src', imageUrl);
+
+        // Update alt attribute dynamically
+        const altText = `Image of ${mac_name} model ${mac_model} color ${mac_color}`;
+        $('#apple_mac_icon').attr('alt', altText);
+    });
+}
+
+    // Only call loadIbridgeData initially; it will call loadMachineData after mac_color is set
+    loadIbridgeData();
+
+    $('.machine-refresh-desc').on('click', function (e) {
+        e.preventDefault();
+        loadIbridgeData(); // Same logic for refresh
+    });
+});
 </script>


### PR DESCRIPTION
The machine_detail_widget1.php has been updated to provide icons in the clients details summary view.
This no longer relies on the optional iBridge module to provide color. Color is not specified so the generic icon for each Mac is used.